### PR TITLE
update llnl import for spack 1.1

### DIFF
--- a/spack_repo/scd_recipes/packages/r_m_dd_config/package.py
+++ b/spack_repo/scd_recipes/packages/r_m_dd_config/package.py
@@ -5,7 +5,7 @@
 
 from spack_repo.builtin.build_systems.bundle import BundlePackage
 from spack.package import *
-from llnl.util import tty
+from spack.llnl.util import tty
 import os
 import sys
 import glob


### PR DESCRIPTION
referencing the `r_m_dd_config` package in `fnal-develop` yields the following warning:
```
==> Warning: /cvmfs/dune.opensciencegrid.org/dune-spack/spack-develop-fermi/var/spack/repos/scd_recipes/spack_repo/scd_recipes/packages/r_m_dd_config/package.py:8: The `llnl` module will be removed in Spack v1.1
```

this PR updates the recipe to reflect the fact that `llnl` has been renamed to `spack.llnl`, which silences the above warning.