### PR TITLE
update justin dependency

### DIFF
--- a/spack_repo/scd_recipes/packages/justin/package.py
+++ b/spack_repo/scd_recipes/packages/justin/package.py
@@ -23,7 +23,7 @@ class Justin(Package):
     version("01.05.01", sha256="2a593649caf05d57f5875930cb27c4148c9187deae04dbdf776c5588b30bd4f0")
     version("01.03.00", sha256="688b96531c3190b66e4db4c10efb7ccc6e9bcdfad470f4cd6cde934df0d8fb20")
 
-    depends_on("python@3.3:", type=("build", "run"))
+    depends_on("python@3.6:", type=("build", "run"))
     depends_on("rucio-clients", type="run")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Andrew McNab made [this statement](https://dunescience.slack.com/archives/C06M2R1KE5V/p1760452596681469) on the DUNE slack:

> The justIN clients really need Python 3.6 or above as 3.6 is the official SL7 Python3 version.

this PR updates the `justin` recipe to upgrade the minimum required python version from 3.3 to 3.6. in practice this probably doesn't make a difference, as it's very unlikely that spack will try to install python<3.6, but it's worth implementing regardless.