### PR TITLE
Update justIN version to 01.05.02 in its package.py

### DIFF
--- a/spack_repo/scd_recipes/packages/justin/package.py
+++ b/spack_repo/scd_recipes/packages/justin/package.py
@@ -14,7 +14,7 @@ class Justin(Package):
 
     homepage = "https://dunejustin.fnal.gov/"
 
-    url = "https://github.com/DUNE/dune-justin/archive/refs/tags/01.05.01.tar.gz"
+    url = "https://github.com/DUNE/dune-justin/archive/refs/tags/01.05.02.tar.gz"
 
     maintainers("marcmengel", "Andrew-McNab-UK", "calcuttj")
 


### PR DESCRIPTION
The 01.05.02 version fixes SSLContext() deprecation warning messages on Python 3.9 etc when running the justin commands. I've not included an updated version() in package.py. Is that something you do?