### PR TITLE
fix typo in rucio package recipe

### DIFF
--- a/spack_repo/scd_recipes/packages/rucio/package.py
+++ b/spack_repo/scd_recipes/packages/rucio/package.py
@@ -25,7 +25,7 @@ class Rucio(PythonPackage):
 
     depends_on("py-requests", type=("build", "run"))
     depends_on("py-urllib3", type=("build", "run"))
-    depends_on("py-dogpile.cache", type=("build", "run"))
+    depends_on("py-dogpile-cache", type=("build", "run"))
     depends_on("py-tabulate", type=("build", "run"))
     depends_on("py-jsonschema", type=("build", "run"))
     depends_on("py-paramiko", type=("build", "run"))


### PR DESCRIPTION
there's a single-character typo in the `rucio` package recipe: the `dogpile.cache` spack package is called `py-dogpile-cache`, not `py-dogpile.cache`. building an environment with this rucio throws an error when the CLI is invoked, because it can't import `dogpile.cache`.